### PR TITLE
Add appveyor.yml, fix installer for automatic building

### DIFF
--- a/LibkiPrintStation.pro
+++ b/LibkiPrintStation.pro
@@ -37,7 +37,7 @@ else: unix:!android: target.path = /opt/$${TARGET}/bin
 
 HEADERS += \
     backend.h \
-    jamex/JPClibs.h \
+    "jamex/Linux (x64)/JPClibs.h" \
     logutils.h
 
 INCLUDEPATH += 3rdparty/JPClibs/include

--- a/PrintRelease.qml
+++ b/PrintRelease.qml
@@ -79,6 +79,8 @@ ColumnLayout {
 
     TableView {
         id: printJobsTableView
+        Layout.fillWidth: true
+        Layout.fillHeight: true
 
         property var printers
         property var printJobs

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ build_script:
   - dir release
   - copy release\LibkiPrintStation.exe deploy\windows\LibkiPrintStation.exe
   - cd deploy\windows
-  - windeployqt LibkiPrintStation.exe
+  - copy C:\Qt\6.9.3\mingw_64\bin\*.dll .
   - cd ..
   - ISCC.exe installer-wizard.iss
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,8 +23,7 @@ build_script:
   - dir release
   - copy release\LibkiPrintStation.exe deploy\windows\LibkiPrintStation.exe
   - cd deploy\windows
-  - copy C:\Qt\6.9.3\mingw_64\bin\*.dll .
-  - windeployqt LibkiPrintStation.exe
+  - windeployqt6 --release LibkiPrintStation.exe
   - cd ..
   - ISCC.exe installer-wizard.iss
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,54 @@
+# Build worker image (VM template)
+image:
+  - Visual Studio 2022
+
+# Do not build on tags (GitHub and BitBucket)
+skip_tags: true
+
+# branches to build
+branches:
+  only:
+    - main
+
+# scripts that run after cloning repository
+install:
+  - set QTDIR=C:\Qt\6.9.3\mingw_64
+  - set PATH=C:\msys64\mingw64\bin;%QTDIR%\bin;"C:\\Program Files (x86)\\Inno Setup 6";%PATH%
+  - copy "%QTDIR%\libstdc++-6.dll" %QTDIR%\bin\
+  - copy "%QTDIR%\libgcc*" %QTDIR%\bin\
+
+<<<<<<< HEAD
+init:
+  - ps: $blockRdp = $false; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+
+build_script:
+  - qmake6 LibkiPrintStation.pro
+  - type Makefile.Release
+=======
+build_script:
+  - qmake6 LibkiPrintStation.pro
+>>>>>>> 59ebb0d (Add appveyor.yml and add edits to make builds run more smoothly)
+  - mingw32-make
+  - dir release
+  - copy release\LibkiPrintStation.exe deploy\windows\LibkiPrintStation.exe
+  - cd deploy
+  - ISCC.exe installer-wizard.iss
+
+# defines what we can export from the build environment
+artifacts:
+  - path: 'deploy\Output\LibkiPrintStation.exe'
+    name: 'Libki Print Station (Unstable) [$(APPVEYOR_REPO_COMMIT)]'
+
+# deployment configuration, deploy to github releases
+deploy:
+  release: libki-print-station-unstable-v$(APPVEYOR_REPO_COMMIT)
+  description: 'Libki Print Station (Unstable) [$(APPVEYOR_REPO_COMMIT)]'
+  artifact: 'deploy\Output\LibkiPrintStation.exe'
+  provider: GitHub
+  auth_token: $(GITHUB_TOKEN)
+  draft: false
+  prerelease: true
+  force_update: true
+  skip_tags: true
+  on:
+    branch: main

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,7 @@ build_script:
   - copy release\LibkiPrintStation.exe deploy\windows\LibkiPrintStation.exe
   - cd deploy\windows
   - copy C:\Qt\6.9.3\mingw_64\bin\*.dll .
+  - windeployqt LibkiPrintStation.exe
   - cd ..
   - ISCC.exe installer-wizard.iss
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,8 +23,8 @@ build_script:
   - dir release
   - copy release\LibkiPrintStation.exe deploy\windows\LibkiPrintStation.exe
   - cd deploy\windows
-  - ps: $blockRdp = $false; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
   - windeployqt6 --release LibkiPrintStation.exe
+  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
   - cd ..
   - ISCC.exe installer-wizard.iss
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,17 +17,8 @@ install:
   - copy "%QTDIR%\libstdc++-6.dll" %QTDIR%\bin\
   - copy "%QTDIR%\libgcc*" %QTDIR%\bin\
 
-<<<<<<< HEAD
-init:
-  - ps: $blockRdp = $false; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
-
 build_script:
   - qmake6 LibkiPrintStation.pro
-  - type Makefile.Release
-=======
-build_script:
-  - qmake6 LibkiPrintStation.pro
->>>>>>> 59ebb0d (Add appveyor.yml and add edits to make builds run more smoothly)
   - mingw32-make
   - dir release
   - copy release\LibkiPrintStation.exe deploy\windows\LibkiPrintStation.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,14 +27,14 @@ build_script:
 
 # defines what we can export from the build environment
 artifacts:
-  - path: 'deploy\Output\LibkiPrintStation.exe'
+  - path: 'deploy\Output\Libki_Print_Station_Installer.exe'
     name: 'Libki Print Station (Unstable) [$(APPVEYOR_REPO_COMMIT)]'
 
 # deployment configuration, deploy to github releases
 deploy:
   release: libki-print-station-unstable-v$(APPVEYOR_REPO_COMMIT)
   description: 'Libki Print Station (Unstable) [$(APPVEYOR_REPO_COMMIT)]'
-  artifact: 'deploy\Output\LibkiPrintStation.exe'
+  artifact: 'deploy\Output\Libki_Print_Station_Installer.exe'
   provider: GitHub
   auth_token: $(GITHUB_TOKEN)
   draft: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,7 @@ build_script:
   - dir release
   - copy release\LibkiPrintStation.exe deploy\windows\LibkiPrintStation.exe
   - cd deploy\windows
+  - ps: $blockRdp = $false; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
   - windeployqt6 --release LibkiPrintStation.exe
   - cd ..
   - ISCC.exe installer-wizard.iss

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,9 @@ build_script:
   - mingw32-make
   - dir release
   - copy release\LibkiPrintStation.exe deploy\windows\LibkiPrintStation.exe
-  - cd deploy
+  - cd deploy\windows
+  - windeployqt LibkiPrintStation.exe
+  - cd ..
   - ISCC.exe installer-wizard.iss
 
 # defines what we can export from the build environment

--- a/deploy/installer-wizard.iss
+++ b/deploy/installer-wizard.iss
@@ -8,8 +8,8 @@ AppPublisherURL=http://kylehall.info/
 AppSupportURL=http://libki.org/
 AppUpdatesURL=http://libki.org/
 DefaultDirName={pf}\LibkiPrintStation
-DefaultGroupName=Libki Jamex Client
-OutputBaseFilename=Libki_Jamex_Installer
+DefaultGroupName=Libki Print Station
+OutputBaseFilename=Libki_Print_Station_Installer
 Compression=lzma
 AllowNoIcons=yes
 
@@ -23,7 +23,7 @@ Name: {app}\logs
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Icons]
-Name: "{userdesktop}\Libki Jamex client"; Filename: "{app}\LibkiPrintStation.exe"; Tasks: desktopicon
+Name: "{userdesktop}\Libki Print Station"; Filename: "{app}\LibkiPrintStation.exe"; Tasks: desktopicon
 
 [CustomMessages]
 NameAndVersion=%1 version %2

--- a/main.qml
+++ b/main.qml
@@ -67,6 +67,8 @@ Window {
 
     Row {
         id: actionsScreen
+        height: parent.height
+        width: parent.width
         visible: false
 
         ColumnLayout {
@@ -80,7 +82,6 @@ Window {
                 title: qsTr("1. Add funds via coinbox")
 
                 label: Label {
-                    font.pointSize: 14
                     x: paymentGroupBox.leftPadding
                     width: paymentGroupBox.availableWidth
                     text: paymentGroupBox.title


### PR DESCRIPTION
Add appveyor.yml to enable build workflow. Ancillary fixes included in this request:

- Fix to the installer wizard to have the correct name
- Fix to the project file to point to the correct header file
- Replace the JPClibs.dll with one that runs
- Add default width and height to qml files to make them render
- Remove font size from main.qml