### PR TITLE
Security: replace eval() JSON parsing with JSON.parse() (Closes #9)

### DIFF
--- a/LibkiBalance.qml
+++ b/LibkiBalance.qml
@@ -53,7 +53,7 @@ GridLayout {
                                                              password)
 
         Functions.request(url, function (o) {
-            var data = eval('new Object(' + o.responseText + ')')
+            var data = JSON.parse(o.responseText)
 
             let first_check = balance === "";
             balance = parseFloat(data.funds)

--- a/PaymentWindow.qml
+++ b/PaymentWindow.qml
@@ -103,7 +103,7 @@ RowLayout {
             Functions.request(url, function (o) {
                 waitDialog.close()
                 // translate response into an object
-                var d = eval('new Object(' + o.responseText + ')')
+                var d = JSON.parse(o.responseText)
 
                 let messageText
                 if (d.success) {

--- a/PrintRelease.qml
+++ b/PrintRelease.qml
@@ -52,7 +52,7 @@ ColumnLayout {
         Functions.request(url, function (o) {
             waitDialog.close()
             // translate response into an object
-            var d = eval('new Object(' + o.responseText + ')')
+            var d = JSON.parse(o.responseText)
 
             if (d.success) {
                 popupDialogText.text = qsTr(
@@ -324,7 +324,7 @@ ColumnLayout {
                                 Functions.request(url, function (o) {
                                     waitDialog.close();
                                     // translate response into an object
-                                    var d = eval('new Object(' + o.responseText + ')')
+                                    var d = JSON.parse(o.responseText)
 
                                     if (d.success) {
                                         popupDialogText.text = qsTr(
@@ -416,7 +416,7 @@ ColumnLayout {
                 Functions.request(url, function (o) {
                     waitDialog.close()
                     // translate response into an object
-                    var d = eval('new Object(' + o.responseText + ')')
+                    var d = JSON.parse(o.responseText)
 
                     if (d.success) {
                         popupDialogText.text = qsTr(

--- a/main.qml
+++ b/main.qml
@@ -303,7 +303,7 @@ Window {
                                 // log the json response
                                 console.log(o.responseText)
                                 // translate response into object
-                                var d = eval('new Object(' + o.responseText + ')')
+                                var d = JSON.parse(o.responseText)
 
                                 if (d.success) {
                                     loginScreen.visible = false


### PR DESCRIPTION
Closes #9.

## Summary

Replaces six identical `eval('new Object(' + o.responseText + ')')` call sites across four QML files with `JSON.parse(o.responseText)`. This eliminates a latent code-injection vector: in any compromised-server / MITM / malicious-proxy scenario, the kiosk previously would have executed the server response body as JavaScript.

## Root cause

Legacy parsing idiom, likely predating reliable `JSON.parse()` support in the target Qt/QML runtime. The codebase already uses `JSON.parse()` in newer paths (e.g., `PrintRelease.qml` for the print-jobs handler), so the pattern was internally inconsistent.

## Behavior change

For well-formed JSON responses (the common case), behavior is identical. For malformed JSON:

| Before | After |
|---|---|
| `eval()` evaluates the string as JS — undefined behavior, silent garbage | `JSON.parse()` throws `SyntaxError` |

Throwing on malformed input is a strict improvement: the previous behavior masked server-side bugs and provided no defense against a manipulated response.

## Sites changed

- `LibkiBalance.qml:56` — user balance fetch
- `main.qml:306` — login response handler
- `PaymentWindow.qml:106` — fund-transfer response
- `PrintRelease.qml:55`, `:327`, `:419` — print release / funds / cancel responses

4 files, 6 identical one-line replacements.

## Verification

This is a mechanical substitution at six sites sharing an identical pattern. All callers consume the result via property access (`.success`, `.error`, `.funds`, etc.); `JSON.parse()` produces an identically-shaped object for the server's well-formed JSON responses (generated server-side by Perl's `JSON` module, which is standards-conformant).

**Full end-to-end manual verification was not performed for this patch** — the repo has no automated test harness, and a complete kiosk run requires Qt 6 + Jamex hardware against a staging libki-server, which I did not have available. Reviewers are invited to exercise the login / balance / fund-transfer / print-release / print-cancel paths on staging before merging.

## Regression coverage

None added. The repo has no test framework today; adding one is out of scope for a security fix of this size.
