### PR TITLE
Read existing config values during install

### DIFF
--- a/deploy/installer-wizard.iss
+++ b/deploy/installer-wizard.iss
@@ -47,9 +47,11 @@ Filename: "{commonappdata}\Libki\Libki Print Station.ini"; Section: "font"; Key:
 [Code]
 var
   ServerPage: TInputQueryWizardPage;
+  IniPath: string;
 
 procedure InitializeWizard;
 begin
+  IniPath := ExpandConstant('{commonappdata}\Libki\Libki Print Station.ini');
   { Create the pages }
   
   ServerPage := CreateInputQueryPage(wpWelcome,
@@ -59,10 +61,10 @@ begin
   ServerPage.Add('API Key:', False);
   ServerPage.Add('API Request Header Name:', False);
   ServerPage.Add('API Request Header Value:', False);
-  ServerPage.Values[0] := GetIniString("server", "address", "", "{commonappdata}\Libki\Libki Print Station.ini");
-  ServerPage.Values[1] := GetIniString("server", "api_key", "", "{commonappdata}\Libki\Libki Print Station.ini");
-  ServerPage.Values[2] := GetIniString("server", "api_header_name", "", "{commonappdata}\Libki\Libki Print Station.ini");
-  ServerPage.Values[3] := GetIniString("server", "api_header_value", "", "{commonappdata}\Libki\Libki Print Station.ini");
+  ServerPage.Values[0] := GetIniString('server', 'address', '', IniPath);
+  ServerPage.Values[1] := GetIniString('server', 'api_key', '', IniPath);
+  ServerPage.Values[2] := GetIniString('server', 'api_header_name', '', IniPath);
+  ServerPage.Values[3] := GetIniString('server', 'api_header_value', '', IniPath);
 end;
 
 function GetAddress(Param: String): String;

--- a/deploy/installer-wizard.iss
+++ b/deploy/installer-wizard.iss
@@ -39,6 +39,8 @@ AssocingFileExtension=Associating %1 with the %2 file extension...
 [INI]
 Filename: "{commonappdata}\Libki\Libki Print Station.ini"; Section: "server"; Key: "address"; String: "{code:GetAddress}"
 Filename: "{commonappdata}\Libki\Libki Print Station.ini"; Section: "server"; Key: "api_key"; String: "{code:GetApiKey}"
+Filename: "{commonappdata}\Libki\Libki Print Station.ini"; Section: "server"; Key: "customHeaderName"; String: "{code:GetCustomHeaderName}"
+Filename: "{commonappdata}\Libki\Libki Print Station.ini"; Section: "server"; Key: "customHeaderValue"; String: "{code:GetCustomHeaderValue}"
 Filename: "{commonappdata}\Libki\Libki Print Station.ini"; Section: "font"; Key: "font_family"; String: "Arial"
 Filename: "{commonappdata}\Libki\Libki Print Station.ini"; Section: "font"; Key: "font_size"; String: "14"
 
@@ -55,8 +57,12 @@ begin
     'Please specify the Libki server data.');
   ServerPage.Add('Address:', False);
   ServerPage.Add('API Key:', False);
+  ServerPage.Add('API Request Header Name:', False);
+  ServerPage.Add('API Request Header Value:', False);
   ServerPage.Values[0] := GetIniString("server", "address", "", "{commonappdata}\Libki\Libki Print Station.ini");
   ServerPage.Values[1] := GetIniString("server", "api_key", "", "{commonappdata}\Libki\Libki Print Station.ini");
+  ServerPage.Values[2] := GetIniString("server", "api_header_name", "", "{commonappdata}\Libki\Libki Print Station.ini");
+  ServerPage.Values[3] := GetIniString("server", "api_header_value", "", "{commonappdata}\Libki\Libki Print Station.ini");
 end;
 
 function GetAddress(Param: String): String;
@@ -67,4 +73,14 @@ end;
 function GetApiKey(Param: String): String;
 begin
   Result := ServerPage.Values[1];
+end;
+
+function GetCustomHeaderName(Param: String): String;
+begin
+  Result := ServerPage.Values[2];
+end;
+
+function GetCustomHeaderValue(Param: String): String;
+begin
+  Result := ServerPage.Values[3];
 end;

--- a/deploy/installer-wizard.iss
+++ b/deploy/installer-wizard.iss
@@ -55,6 +55,8 @@ begin
     'Please specify the Libki server data.');
   ServerPage.Add('Address:', False);
   ServerPage.Add('API Key:', False);
+  ServerPage.Values[0] := GetIniString("server", "address", "", "{commonappdata}\Libki\Libki Print Station.ini");
+  ServerPage.Values[1] := GetIniString("server", "api_key", "", "{commonappdata}\Libki\Libki Print Station.ini");
 end;
 
 function GetAddress(Param: String): String;

--- a/deploy/installer-wizard.iss
+++ b/deploy/installer-wizard.iss
@@ -63,8 +63,8 @@ begin
   ServerPage.Add('API Request Header Value:', False);
   ServerPage.Values[0] := GetIniString('server', 'address', '', IniPath);
   ServerPage.Values[1] := GetIniString('server', 'api_key', '', IniPath);
-  ServerPage.Values[2] := GetIniString('server', 'api_header_name', '', IniPath);
-  ServerPage.Values[3] := GetIniString('server', 'api_header_value', '', IniPath);
+  ServerPage.Values[2] := GetIniString('server', 'customHeaderName', '', IniPath);
+  ServerPage.Values[3] := GetIniString('server', 'customHeaderValue', '', IniPath);
 end;
 
 function GetAddress(Param: String): String;


### PR DESCRIPTION
Closes #17. Also adds support for API custom request headers directly to the installer.